### PR TITLE
add ports for CanSimulator

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,5 +16,7 @@ services:
       - /tmp/.X11-unix:/tmp/.X11-unix
       - /run/user:/run/user
       - /home/${USER}/${WORK_DIR}:/home/user/work
+    ports:
+      - 49152:49152
 
 


### PR DESCRIPTION
CanSimulator接続の為のport追記です。
installで落ちてきたymlとは他行の違いはありましたが、
ports変更差分の2行のみをPRしております。